### PR TITLE
Feature/auto generate entity

### DIFF
--- a/src/main/java/questionbox/clone/entity/Question.java
+++ b/src/main/java/questionbox/clone/entity/Question.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -20,12 +21,8 @@ import java.util.UUID;
 public class Question {
 
 	@Id
-
-// generator の指定がなくても uuid で作られる
-// 2021-04-13 19:05:05.408 TRACE 9033 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [7] as [BINARY] - [0bb353f0-4c77-42cb-a8c3-bd67570243ca]
-//	@GeneratedValue( generator = "uuid2" )
-//	@GenericGenerator( name = "uuid2", strategy = "uuid2" )
 	@GeneratedValue
+	@Type(type="uuid-char")
 	private UUID id;
 
 	/**

--- a/src/main/java/questionbox/clone/entity/Question.java
+++ b/src/main/java/questionbox/clone/entity/Question.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
 /**
@@ -18,6 +19,7 @@ import javax.persistence.Id;
 public class Question {
 
 	@Id
+	// TODO: id を自動生成する
 	private int id;
 
 	/**

--- a/src/main/java/questionbox/clone/entity/Question.java
+++ b/src/main/java/questionbox/clone/entity/Question.java
@@ -3,24 +3,30 @@ package questionbox.clone.entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import java.util.UUID;
 
 /**
  * ユーザへの質問
  */
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 @Entity
 public class Question {
 
 	@Id
-	// TODO: id を自動生成する
-	private int id;
+
+// generator の指定がなくても uuid で作られる
+// 2021-04-13 19:05:05.408 TRACE 9033 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [7] as [BINARY] - [0bb353f0-4c77-42cb-a8c3-bd67570243ca]
+//	@GeneratedValue( generator = "uuid2" )
+//	@GenericGenerator( name = "uuid2", strategy = "uuid2" )
+	@GeneratedValue
+	private UUID id;
 
 	/**
 	 * 質問者
@@ -51,5 +57,14 @@ public class Question {
 	 * 削除済み（アーカイブ済み）フラグ
 	 */
 	boolean archived;
+
+	public Question(String questioner, String post, String respondent, String answer, boolean answered, boolean archived) {
+		this.questioner = questioner;
+		this.post = post;
+		this.respondent = respondent;
+		this.answer = answer;
+		this.answered = answered;
+		this.archived = archived;
+	}
 
 }

--- a/src/main/java/questionbox/clone/repository/QuestionRepository.java
+++ b/src/main/java/questionbox/clone/repository/QuestionRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import questionbox.clone.entity.Question;
 
+import java.util.UUID;
+
 @Repository
-public interface QuestionRepository extends JpaRepository<Question, Integer> {
+public interface QuestionRepository extends JpaRepository<Question, UUID> {
 
 }

--- a/src/main/resources/db/migration/V1.0.0__create_table.sql
+++ b/src/main/resources/db/migration/V1.0.0__create_table.sql
@@ -1,1 +1,1 @@
-create table question (id integer not null, answered boolean not null, archived boolean not null, answer varchar(255), post varchar(255), questioner varchar(255), respondent varchar(255), primary key (id))
+create table question (id varchar(255) not null, answered boolean not null, archived boolean not null, answer varchar(255), post varchar(255), questioner varchar(255), respondent varchar(255), primary key (id))

--- a/src/main/resources/db/migration/V1.0.1__insert_records.sql
+++ b/src/main/resources/db/migration/V1.0.1__insert_records.sql
@@ -1,1 +1,1 @@
-insert into question (answered, archived, answer, post, questioner, respondent, id) values (true, true, '回答','質問内容', 'やまざき', 'きよた', 1);
+insert into question (answered, archived, answer, post, questioner, respondent, id) values (true, true, '回答','質問内容', 'やまざき', 'きよた', 'ce97e242-c544-42e2-ab45-abffd6754679');

--- a/src/test/java/questionbox/clone/controller/QuestionControllerTests.java
+++ b/src/test/java/questionbox/clone/controller/QuestionControllerTests.java
@@ -36,7 +36,7 @@ class QuestionControllerTests {
 	@Test
 	void shouldReturnQuestionList() throws Exception {
 
-		var question = new Question(1, "質問", "回答", "やまざき", "きよた", true, true);
+		var question = new Question("質問", "回答", "やまざき", "きよた", true, true);
 		List<Question> questions = Arrays.asList(question);
 		when(service.findAll()).thenReturn(questions);
 

--- a/src/test/java/questionbox/clone/entity/QuestionTests.java
+++ b/src/test/java/questionbox/clone/entity/QuestionTests.java
@@ -17,11 +17,11 @@ public class QuestionTests {
 
 	@Test
 	void mapping() {
-		// for check DML
-		 var newQuestion = new Question("質問", "回答", "やまざき", "きよた", true, true);
-	 	 em.persistAndFlush(newQuestion);
+//		 for check DML
+//		 var newQuestion = new Question("質問", "回答", "やまざき", "きよた", true, true);
+//	 	 em.persistAndFlush(newQuestion);
 
-//		var question = this.em.find(Question.class, UUID.fromString("16294490-5fe5-43b1-925e-2e60b75c1b26"));
-//		assertThat(question.getAnswer()).isEqualTo("回答");
+		var question = this.em.find(Question.class, UUID.fromString("16294490-5fe5-43b1-925e-2e60b75c1b26"));
+		assertThat(question.getAnswer()).isEqualTo("回答");
 	}
 }

--- a/src/test/java/questionbox/clone/entity/QuestionTests.java
+++ b/src/test/java/questionbox/clone/entity/QuestionTests.java
@@ -16,11 +16,10 @@ public class QuestionTests {
 	@Test
 	void mapping() {
 		// for check DML
-		// var content = new Content("回答", "質問内容");
-		// var question = new Question(1, content, "やまざき", "きよた", true, true);
-		// em.persistAndFlush(question);
+		// var newQuestion = new Question(100, "質問", "回答", "やまざき", "きよた", true, true);
+	 	// em.persistAndFlush(newQuestion);
+
 		var question = this.em.find(Question.class, 1);
 		assertThat(question.getAnswer()).isEqualTo("回答");
 	}
-
 }

--- a/src/test/java/questionbox/clone/entity/QuestionTests.java
+++ b/src/test/java/questionbox/clone/entity/QuestionTests.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -16,10 +18,10 @@ public class QuestionTests {
 	@Test
 	void mapping() {
 		// for check DML
-		// var newQuestion = new Question(100, "質問", "回答", "やまざき", "きよた", true, true);
-	 	// em.persistAndFlush(newQuestion);
+		 var newQuestion = new Question("質問", "回答", "やまざき", "きよた", true, true);
+	 	 em.persistAndFlush(newQuestion);
 
-		var question = this.em.find(Question.class, 1);
-		assertThat(question.getAnswer()).isEqualTo("回答");
+//		var question = this.em.find(Question.class, UUID.fromString("16294490-5fe5-43b1-925e-2e60b75c1b26"));
+//		assertThat(question.getAnswer()).isEqualTo("回答");
 	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,3 +11,5 @@ spring:
       - "classpath:db/data.sql"
   flyway:
     enabled: false
+# パラメータの値をログに表示 ex.) binding parameter [1] as [INTEGER] - [1]
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/src/test/resources/db/data.sql
+++ b/src/test/resources/db/data.sql
@@ -1,2 +1,2 @@
-insert into question (answered, archived, answer, post, questioner, respondent, id) values (true, true, '回答','質問内容', 'やまざき', 'きよた', 1);
-insert into question (answered, archived, answer, post, questioner, respondent, id) values (true, true, '回答2','質問内容2', 'やまざき2', 'きよた2', 2);
+insert into question (answered, archived, answer, post, questioner, respondent, id) values (true, true, '回答','質問内容', 'やまざき', 'きよた', '16294490-5fe5-43b1-925e-2e60b75c1b26');
+insert into question (answered, archived, answer, post, questioner, respondent, id) values (true, true, '回答2','質問内容2', 'やまざき2', 'きよた2', 'f549acf4-3b8a-4f80-b828-cd7a6f4bf535');


### PR DESCRIPTION
# 注意

***一度、table(flyway_schema_history, question) を削除した後、アプリを起動してください！***

後述の uuid への変更を実施したため。

---
# テストではバインドした値を表示するよう変更

- テストではバインドした値を表示するよう変更

```shell
Hibernate: insert into question (answer, answered, archived, post, questioner, respondent, id) values (?, ?, ?, ?, ?, ?, ?)

2021-04-13 16:50:24.842 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [1] as [VARCHAR] - [きよた]
2021-04-13 16:50:24.842 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [2] as [BOOLEAN] - [true]
2021-04-13 16:50:24.842 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [3] as [BOOLEAN] - [true]
2021-04-13 16:50:24.843 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [4] as [VARCHAR] - [回答]
2021-04-13 16:50:24.843 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [5] as [VARCHAR] - [質問]
2021-04-13 16:50:24.843 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [6] as [VARCHAR] - [やまざき]
2021-04-13 16:50:24.844 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [7] as [INTEGER] - [100]

Hibernate: select question0_.id as id1_0_0_, question0_.answer as answer2_0_0_, question0_.answered as answered3_0_0_, question0_.archived as archived4_0_0_, question0_.post as post5_0_0_, question0_.questioner as question6_0_0_, question0_.respondent as responde7_0_0_ from question question0_ where question0_.id=?

2021-04-13 16:50:24.851 TRACE 6576 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [1] as [INTEGER] - [1]
```

---
# uuid に変換し、テストデータとマイグレーションデータを変更

- generator の指定がなくても、binary 型として uuid で作られる

```
2021-04-13 19:05:05.408 TRACE 9033 --- [           main] o.h.type.descriptor.sql.BasicBinder      : binding parameter [7] as [BINARY] - [0bb353f0-4c77-42cb-a8c3-bd67570243ca]

// 以下の指定は、おそらく不要
//	@GeneratedValue( generator = "uuid2" )
//	@GenericGenerator( name = "uuid2", strategy = "uuid2" )
```

- binary 型であることが原因となり、h2 へのテストデータの insert でエラーとなるため、 @type で型を指定
    - `varchar(255)` として保存される

```
	@type(type="uuid-char")
// nested exception is org.h2.jdbc.JdbcSQLDataException: Hexadecimal string contains non-hex character: "16294490-5fe5-43b1-925e-2e60b75c1b26"; SQL statement:
```
